### PR TITLE
Fix TS7010 'missing return types'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ interface EDictionary {
      * Iterates through the EDictionary
      * @param fn Provides (obj: any, i: number) to your function
      */
-    forEach(fn: (obj: any, i: number) => void)
+    forEach(fn: (obj: any, i: number) => void): void
 
     /**
      * Adds an object to the EDictionary. The object *MUST* have a nid/id property as defined in the nengiConfig
@@ -42,7 +42,7 @@ declare namespace nengi {
         //on(event: 'disconnect', callback: (client: any) => {}): void
         //on(event: string, callback: (a: any, b: any, c: any) => {}): void
         //on(event: string, callback: (a: any, b: any) => {}): void
-        on(event: string, callback: (client: any) => void)
+        on(event: string, callback: (client: any) => void): void
 
         // Warning: this function is only present if a nengi hooks mixin has been used.
         emitCommands(): void
@@ -163,7 +163,7 @@ declare namespace nengi {
         readNetworkAndEmit(): any
 
         // TODO
-        on(event: string, callback: (message: any) => void)
+        on(event: string, callback: (message: any) => void): void
     }
 
     /**


### PR DESCRIPTION
Add's missing return types to fix TS7010 errors

```
node_modules/nengi/index.d.ts(10,5): error TS7010: 'forEach', which lacks return-type annotation, implicitly has an 'any' return type.
[1] node_modules/nengi/index.d.ts(45,9): error TS7010: 'on', which lacks return-type annotation, implicitly has an 'any' return type.
[1] node_modules/nengi/index.d.ts(166,9): error TS7010: 'on', which lacks return-type annotation, implicitly has an 'any' return type.
```